### PR TITLE
chore: apply prettier formatting

### DIFF
--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -5,10 +5,7 @@ withDefaults(
     tone?: "cream-on-dark" | "charcoal-on-light";
   }>(),
   {
-    items: () => [
-      { text: "Free forever" },
-      { text: "No login" },
-    ],
+    items: () => [{ text: "Free forever" }, { text: "No login" }],
     tone: "charcoal-on-light",
   },
 );

--- a/app/components/WhatsAppBar.vue
+++ b/app/components/WhatsAppBar.vue
@@ -34,9 +34,7 @@ onUnmounted(() => {
       href="#signup"
       class="bg-saffron-500 hover:bg-saffron-600 text-charcoal-800 fixed bottom-8 right-8 z-30 hidden items-center gap-2 rounded-full px-5 py-3 shadow-2xl ring-1 ring-black/5 transition-colors md:inline-flex"
     >
-      <span class="font-body-en text-[1.0625rem] font-medium">
-        Join free
-      </span>
+      <span class="font-body-en text-[1.0625rem] font-medium"> Join free </span>
       <UIcon name="i-lucide-arrow-right" class="h-4 w-4" />
     </a>
   </Transition>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,8 +5,7 @@ useSeoMeta({
   ogTitle: "Kabbalah Academy India — Authentic Kabbalah, Free & Online",
   description:
     "Learn authentic Kabbalah in India — a free online introductory course taught live in English by Indian students of Bnei Baruch. Join free.",
-  ogDescription:
-    "Real Kabbalah. In India. Free, online, taught live.",
+  ogDescription: "Real Kabbalah. In India. Free, online, taught live.",
   // Static share card in public/ — composed from a real convention frame;
   // no runtime og-image generation needed.
   ogImage: "https://kabbalahindia.com/og-image.jpg",

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,5 +1,5 @@
-import { START_LOCATION } from "vue-router";
 import type { RouterConfig } from "@nuxt/schema";
+import { START_LOCATION } from "vue-router";
 
 // Custom scroll handling so deep links like /#signup land on the right section.
 export default <RouterConfig>{
@@ -27,7 +27,9 @@ export default <RouterConfig>{
       if (from === START_LOCATION) {
         return new Promise<false>((resolve) => {
           const jump = () =>
-            document.querySelector(hash)?.scrollIntoView({ behavior: "instant" });
+            document
+              .querySelector(hash)
+              ?.scrollIntoView({ behavior: "instant" });
           requestAnimationFrame(() => {
             jump();
             if (document.readyState !== "complete") {


### PR DESCRIPTION
Runs `pnpm format` to resolve Prettier formatting issues in 4 files. Pure formatting changes (line wrapping + import ordering), no logic changes.

- `app/components/TrustStrip.vue`
- `app/components/WhatsAppBar.vue`
- `app/pages/index.vue`
- `app/router.options.ts`

`pnpm lint` and `prettier --check .` both pass.