### PR TITLE
feat: Meta Pixel + Conversions API + Umami signup event

### DIFF
--- a/app/components/SectionFinalCTA.vue
+++ b/app/components/SectionFinalCTA.vue
@@ -27,9 +27,13 @@ const submitting = ref(false);
 const submitted = ref(false);
 const submitError = ref("");
 
+const { $metaTrack, $umamiTrack } = useNuxtApp();
+
 const onSubmit = async () => {
   submitting.value = true;
   submitError.value = "";
+  // Shared id so the browser Pixel Lead and the server-side CAPI Lead dedupe.
+  const eventId = crypto.randomUUID();
   try {
     await $fetch("/api/signup", {
       method: "POST",
@@ -38,9 +42,14 @@ const onSubmit = async () => {
         whatsapp: state.whatsapp,
         email: state.email,
         website: state.website,
+        eventId,
       },
     });
     submitted.value = true;
+    // Fire the conversion through both analytics — Meta for ad optimization,
+    // Umami for first-party funnel/Goal tracking.
+    $metaTrack("Lead", { content_name: "signup" }, { eventID: eventId });
+    $umamiTrack("signup");
   } catch (err: unknown) {
     const e = err as { statusCode?: number; statusMessage?: string };
     submitError.value =

--- a/app/plugins/meta-pixel.client.ts
+++ b/app/plugins/meta-pixel.client.ts
@@ -1,0 +1,68 @@
+// Meta Pixel loader. Mirrors umami.client.ts: reads the ID from public runtime
+// config and skips entirely when unset, so dev/preview stay clean until
+// NUXT_PUBLIC_META_PIXEL_ID is provided. Fires PageView on load; the Lead
+// event is fired from the sign-up form on success (see SectionFinalCTA.vue),
+// with a shared event_id so the server-side CAPI event dedupes against it.
+
+type Fbq = ((...args: unknown[]) => void) & {
+  callMethod?: (...args: unknown[]) => void;
+  queue: unknown[];
+  loaded: boolean;
+  version: string;
+  push: Fbq;
+};
+
+declare global {
+  interface Window {
+    fbq?: Fbq;
+    _fbq?: Fbq;
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const { metaPixelId } = useRuntimeConfig().public;
+
+  // Provide a no-op-safe tracker regardless, so callers never need to guard
+  // on window.fbq existing. When the Pixel is disabled it simply does nothing.
+  const track = (
+    event: string,
+    params?: Record<string, unknown>,
+    options?: { eventID?: string },
+  ) => {
+    window.fbq?.("track", event, params ?? {}, options);
+  };
+
+  if (!metaPixelId) {
+    return { provide: { metaTrack: track } };
+  }
+
+  // Standard Meta Pixel bootstrap (the official snippet, hand-typed).
+  const fbq: Fbq = function (...args: unknown[]) {
+    if (fbq.callMethod) {
+      fbq.callMethod(...args);
+    } else {
+      fbq.queue.push(args);
+    }
+  } as Fbq;
+
+  if (!window._fbq) window._fbq = fbq;
+  fbq.push = fbq;
+  fbq.loaded = true;
+  fbq.version = "2.0";
+  fbq.queue = [];
+  window.fbq = fbq;
+
+  useHead({
+    script: [
+      {
+        defer: true,
+        src: "https://connect.facebook.net/en_US/fbevents.js",
+      },
+    ],
+  });
+
+  window.fbq("init", metaPixelId);
+  window.fbq("track", "PageView");
+
+  return { provide: { metaTrack: track } };
+});

--- a/app/plugins/umami.client.ts
+++ b/app/plugins/umami.client.ts
@@ -1,7 +1,26 @@
+type Umami = {
+  track: (event: string, data?: Record<string, unknown>) => void;
+};
+
+declare global {
+  interface Window {
+    umami?: Umami;
+  }
+}
+
 export default defineNuxtPlugin(() => {
   const { umamiWebsiteId } = useRuntimeConfig().public;
 
-  if (!umamiWebsiteId) return;
+  // Symmetric with meta-pixel.client.ts: a no-op-safe tracker so callers never
+  // need to guard on window.umami. Fire the same funnel actions through both
+  // ($umamiTrack here, $metaTrack there) to keep the two analytics in step.
+  const track = (event: string, data?: Record<string, unknown>) => {
+    window.umami?.track(event, data);
+  };
+
+  if (!umamiWebsiteId) {
+    return { provide: { umamiTrack: track } };
+  }
 
   useHead({
     script: [
@@ -12,4 +31,6 @@ export default defineNuxtPlugin(() => {
       },
     ],
   });
+
+  return { provide: { umamiTrack: track } };
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,11 +146,23 @@ export default defineNuxtConfig({
     // chat_id from https://api.telegram.org/bot<TOKEN>/getUpdates
     telegramBotToken: "",
     telegramChatId: "",
+    // Meta Conversions API (CAPI) — server-side Lead events, deduped against
+    // the browser Pixel via a shared event_id. Set the System-User access
+    // token via NUXT_META_CAPI_ACCESS_TOKEN. When empty (or the Pixel ID is
+    // unset), the server skips CAPI delivery.
+    metaCapiAccessToken: "",
+    // Optional. Set NUXT_META_CAPI_TEST_EVENT_CODE while validating events in
+    // Events Manager → Test Events; leave empty in production.
+    metaCapiTestEventCode: "",
     public: {
       whatsappUrl: "https://chat.whatsapp.com/placeholder",
       // Self-hosted Umami at https://umami.weburz.com. Set the site UUID via
       // NUXT_PUBLIC_UMAMI_WEBSITE_ID — when empty, app.vue skips the script.
       umamiWebsiteId: "",
+      // Meta Pixel ID. Set via NUXT_PUBLIC_META_PIXEL_ID — when empty, the
+      // meta-pixel.client.ts plugin skips loading the Pixel entirely. Also
+      // used server-side to build the CAPI endpoint URL.
+      metaPixelId: "",
     },
   },
 

--- a/server/api/signup.post.ts
+++ b/server/api/signup.post.ts
@@ -1,10 +1,13 @@
 import * as v from "valibot";
+import { sendMetaCapiLead } from "../utils/meta";
 import { sendTelegramSignup } from "../utils/telegram";
 
 const signupSchema = v.object({
   name: v.pipe(v.string(), v.trim(), v.minLength(2), v.maxLength(120)),
   whatsapp: v.pipe(v.string(), v.trim(), v.regex(/^\d{10}$/)),
   email: v.pipe(v.string(), v.trim(), v.email(), v.maxLength(254)),
+  // Shared with the browser Pixel's Lead event so Meta dedupes the two.
+  eventId: v.optional(v.pipe(v.string(), v.maxLength(100))),
   // Honeypot — accept any string, but reject silently if non-empty.
   // The schema MUST NOT enforce empty here, otherwise we'd return 400 and
   // tip off the bot. We check the value below.
@@ -57,6 +60,9 @@ export default defineEventHandler(async (event) => {
     signupWebhookToken,
     telegramBotToken,
     telegramChatId,
+    metaCapiAccessToken,
+    metaCapiTestEventCode,
+    public: { metaPixelId },
   } = useRuntimeConfig(event);
 
   // Fire generic webhook + Telegram in parallel. Both are independent and
@@ -92,6 +98,34 @@ export default defineEventHandler(async (event) => {
           );
         },
       ),
+    );
+  }
+
+  // Meta Conversions API — server-side mirror of the browser Pixel's Lead
+  // event, deduped via the shared eventId. Gated on both the Pixel ID and the
+  // CAPI token so it stays dormant until configured.
+  if (metaPixelId && metaCapiAccessToken) {
+    deliveries.push(
+      sendMetaCapiLead(
+        metaPixelId,
+        metaCapiAccessToken,
+        {
+          email: submission.email,
+          whatsapp: submission.whatsapp,
+          eventId: parsed.output.eventId,
+          eventSourceUrl: getRequestHeader(event, "referer"),
+          clientIp: submission.ip === "unknown" ? null : submission.ip,
+          userAgent: submission.userAgent,
+          fbp: getCookie(event, "_fbp") ?? null,
+          fbc: getCookie(event, "_fbc") ?? null,
+        },
+        metaCapiTestEventCode || undefined,
+      ).catch((err) => {
+        console.error(
+          "[signup] meta capi delivery failed",
+          err instanceof Error ? err.message : err,
+        );
+      }),
     );
   }
 

--- a/server/utils/meta.ts
+++ b/server/utils/meta.ts
@@ -1,0 +1,86 @@
+// Meta Conversions API (CAPI) — server-side Lead events. Sent alongside the
+// browser Pixel and deduplicated by Meta via a shared event_id, so leads still
+// land when the browser Pixel is blocked (ad-blockers, iOS tracking limits).
+// https://developers.facebook.com/docs/marketing-api/conversions-api
+
+const GRAPH_API_VERSION = "v21.0";
+
+export type MetaCapiLead = {
+  email: string; // already lowercased, e.g. "user@example.com"
+  whatsapp: string; // "+919876543210"
+  eventId?: string; // shared with the browser Pixel for dedup
+  eventSourceUrl?: string; // the page the lead came from
+  clientIp?: string | null;
+  userAgent?: string | null;
+  fbp?: string | null; // _fbp cookie
+  fbc?: string | null; // _fbc cookie
+  eventTime?: number; // unix seconds; defaults to now
+};
+
+// Meta requires PII normalized then SHA-256 hashed (lowercase hex).
+const sha256Hex = async (value: string): Promise<string> => {
+  const data = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+export const normalizeEmail = (email: string): string =>
+  email.trim().toLowerCase();
+
+// "+919876543210" → "919876543210" (digits only, country code included).
+export const normalizePhone = (waWithPlus: string): string =>
+  waWithPlus.replace(/\D/g, "");
+
+/**
+ * Build the CAPI request body for a single Lead event. Pure aside from the
+ * async hashing — easy to unit-test.
+ */
+export const buildMetaCapiPayload = async (
+  lead: MetaCapiLead,
+  testEventCode?: string,
+): Promise<Record<string, unknown>> => {
+  const [em, ph] = await Promise.all([
+    sha256Hex(normalizeEmail(lead.email)),
+    sha256Hex(normalizePhone(lead.whatsapp)),
+  ]);
+
+  const userData: Record<string, unknown> = { em: [em], ph: [ph] };
+  if (lead.clientIp) userData.client_ip_address = lead.clientIp;
+  if (lead.userAgent) userData.client_user_agent = lead.userAgent;
+  if (lead.fbp) userData.fbp = lead.fbp;
+  if (lead.fbc) userData.fbc = lead.fbc;
+
+  const event: Record<string, unknown> = {
+    event_name: "Lead",
+    event_time: lead.eventTime ?? Math.floor(Date.now() / 1000),
+    action_source: "website",
+    user_data: userData,
+  };
+  if (lead.eventId) event.event_id = lead.eventId;
+  if (lead.eventSourceUrl) event.event_source_url = lead.eventSourceUrl;
+
+  return {
+    data: [event],
+    ...(testEventCode ? { test_event_code: testEventCode } : {}),
+  };
+};
+
+export const sendMetaCapiLead = async (
+  pixelId: string,
+  accessToken: string,
+  lead: MetaCapiLead,
+  testEventCode?: string,
+): Promise<void> => {
+  const body = await buildMetaCapiPayload(lead, testEventCode);
+  await $fetch(
+    `https://graph.facebook.com/${GRAPH_API_VERSION}/${pixelId}/events`,
+    {
+      method: "POST",
+      query: { access_token: accessToken },
+      body,
+      timeout: 5000,
+    },
+  );
+};

--- a/tests/server/utils/meta.test.ts
+++ b/tests/server/utils/meta.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMetaCapiPayload,
+  normalizeEmail,
+  normalizePhone,
+} from "~~/server/utils/meta";
+
+describe("normalizeEmail", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeEmail("  Priya@Example.COM ")).toBe("priya@example.com");
+  });
+});
+
+describe("normalizePhone", () => {
+  it("strips the plus and all non-digits, keeping the country code", () => {
+    expect(normalizePhone("+91 98765 43210")).toBe("919876543210");
+    expect(normalizePhone("+919876543210")).toBe("919876543210");
+  });
+});
+
+describe("buildMetaCapiPayload", () => {
+  const baseLead = {
+    email: "priya@example.com",
+    whatsapp: "+919876543210",
+    eventId: "evt-123",
+    eventSourceUrl: "https://kabbalahindia.com/#signup",
+    clientIp: "203.0.113.7",
+    userAgent: "Mozilla/5.0",
+    eventTime: 1_750_000_000,
+  };
+
+  it("emits a single Lead event with website action_source", async () => {
+    const payload = await buildMetaCapiPayload(baseLead);
+    const event = (payload.data as Record<string, unknown>[])[0]!;
+    expect(event.event_name).toBe("Lead");
+    expect(event.action_source).toBe("website");
+    expect(event.event_id).toBe("evt-123");
+    expect(event.event_source_url).toBe("https://kabbalahindia.com/#signup");
+    expect(event.event_time).toBe(1_750_000_000);
+  });
+
+  it("hashes email and phone (never sends them in the clear)", async () => {
+    const payload = await buildMetaCapiPayload(baseLead);
+    const event = (payload.data as Record<string, unknown>[])[0]!;
+    const userData = event.user_data as Record<string, string[]>;
+    expect(userData.em[0]).toMatch(/^[0-9a-f]{64}$/);
+    expect(userData.ph[0]).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(payload)).not.toContain("priya@example.com");
+    expect(JSON.stringify(payload)).not.toContain("919876543210");
+  });
+
+  it("hashes are stable for the same normalized input", async () => {
+    const a = await buildMetaCapiPayload(baseLead);
+    const b = await buildMetaCapiPayload({
+      ...baseLead,
+      email: "  PRIYA@example.com  ",
+    });
+    const em = (data: typeof a) =>
+      (
+        (data.data as Record<string, unknown>[])[0]!.user_data as Record<
+          string,
+          string[]
+        >
+      ).em[0];
+    expect(em(a)).toBe(em(b));
+    expect(em(a)).toHaveLength(64);
+  });
+
+  it("passes client ip and user agent into user_data when present", async () => {
+    const payload = await buildMetaCapiPayload(baseLead);
+    const userData = (payload.data as Record<string, unknown>[])[0]!
+      .user_data as Record<string, unknown>;
+    expect(userData.client_ip_address).toBe("203.0.113.7");
+    expect(userData.client_user_agent).toBe("Mozilla/5.0");
+  });
+
+  it("includes test_event_code only when provided", async () => {
+    expect(await buildMetaCapiPayload(baseLead)).not.toHaveProperty(
+      "test_event_code",
+    );
+    const tagged = await buildMetaCapiPayload(baseLead, "TEST123");
+    expect(tagged.test_event_code).toBe("TEST123");
+  });
+});


### PR DESCRIPTION
Instruments the signup conversion across three trackers so we can optimize ad spend and measure the funnel first-party.

## What's added
- **Browser Meta Pixel** — `app/plugins/meta-pixel.client.ts`, mirrors the Umami plugin pattern. Loads only when `NUXT_PUBLIC_META_PIXEL_ID` is set, fires `PageView`, and exposes a no-op-safe `$metaTrack`.
- **Conversions API (CAPI)** — `server/utils/meta.ts` + `server/api/signup.post.ts`. Server-side `Lead` event with SHA-256-hashed email/phone, deduped against the browser Pixel via a shared `event_id`. Pulls `_fbp`/`_fbc` cookies + IP/UA for match quality. Gated on Pixel ID **and** `NUXT_META_CAPI_ACCESS_TOKEN`.
- **Umami custom event** — `$umamiTrack` helper added to the Umami plugin; fires a `signup` event alongside the Pixel `Lead` so Goals/Funnels light up (today every session reads as a bounce because only pageviews are tracked).

## Config (all dormant until set, like Umami)
| Env var | Purpose |
| --- | --- |
| `NUXT_PUBLIC_META_PIXEL_ID` | Browser Pixel + CAPI endpoint |
| `NUXT_META_CAPI_ACCESS_TOKEN` | CAPI system-user token |
| `NUXT_META_CAPI_TEST_EVENT_CODE` | optional, for Events Manager → Test Events |

## Tests
- `tests/server/utils/meta.test.ts` covers payload shape, PII hashing (asserts raw email/phone never appear), dedup id, and test-event-code gating.
- `pnpm lint` + `pnpm test` green.